### PR TITLE
Added annotations and routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ WebSocket API engine
 ```python
 from spiderWeb import spiderWeb
 
-class parser():
-	def parse(self, client, data, headers, fileno, addr, *args, **kwargs):
-		yield {'status' : 'successful'}
+server = spiderWeb.host(address='', port=4001)
 
-server = spiderWeb.server({'default' : parser()}, address='', port=4001)
+@server.route_parser
+def parse(self, frame):
+	print('Got WebSocket frame:', frame.data)
+	yield {'status' : 'successful'}
 ```
 # Modules
 


### PR DESCRIPTION
Reworked the data pipeline quite a lot in order to make room for easier usage and more optimized processing. The code now supports:

 * RESP API-alike behavior with `@app.route('/some/path')` which will pipe the `WS_FRAME` object into the given function for processing if the data sent in the frame is `{'_module' : '/some/path'}`.
 * `WS_FRAME` is now passed around instead of various functions, variables and references.
 * supports event overrides such as `@app.on_close`
 * **New version breaks WS_FRAME.large_payload` sized packets**. Only supports up to 255 bytes of payloads again *(for now, need to rework the logic a bit to fix better in this new model)*